### PR TITLE
Replace current text with rich formatted attachment.

### DIFF
--- a/options.html
+++ b/options.html
@@ -26,6 +26,12 @@
             <input type="text" class="form-control" id="slackWebHook" 
                 required placeholder="i.e. https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XxXxXxXxXxXxXxXxXxXxXxXx">
           </div>
+          <div class="form-group">
+          <button id="attachmentEnabled" type="button" class="btn btn-primary active btn-success" data-toggle="button"
+              aria-pressed="true" autocomplete="off">
+            Use rich message (attachment)
+          </button>
+          </div>
         </div>
       </div>
       <div class="row">

--- a/scripts/options.js
+++ b/scripts/options.js
@@ -36,11 +36,27 @@
       }
     });
 
+    $('#attachmentEnabled').click(function() {
+      var button = $(this);
+      if (button.hasClass('active')) {
+        button.text('Use simple message (text)');
+        button.removeClass('btn-success');
+        button.addClass('btn-danger');
+      } else {
+        button.text('Use rich message (attachment)');
+        button.addClass('btn-success');
+        button.removeClass('btn-danger');
+      }
+    });
+
     chrome.storage.local.get('options', function(stored) {
       var options = stored.options;
       if (options) {
         $('#slackUsername').val(options.slack.username);
         $('#slackWebHook').val(options.slack.webhook);
+        if (!options.slack.attachment) {
+          $('#attachmentEnabled').click();
+        }
 
         jQuery.each(['google', 'pandora'], function(i, service) {
           if (!options[service].enabled) {
@@ -69,7 +85,8 @@
       var options = {
         slack: {
           username: username,
-          webhook: webhook
+          webhook: webhook,
+          attachment: $('#attachmentEnabled').hasClass('active'),
         },
         google: {
           enabled: $('#googleEnabled').hasClass('active'),

--- a/scripts/slack-music-notifier.js
+++ b/scripts/slack-music-notifier.js
@@ -26,19 +26,7 @@
         toStore[service + '-song'] = song;
 
         chrome.storage.local.set(toStore, function() {
-          jQuery.post(options.slack.webhook, JSON.stringify({
-            'username' : options.slack.username,
-            'icon_url' : song.cover,
-            "mrkdwn" : true,
-            "attachments": [
-              {
-                "fallback": song.title + ' - ' + song.artist + ' - ' + song.album,
-                "title": song.title,
-                "text": song.artist + ' - ' + song.album,
-                "thumb_url": song.cover
-              }
-            ]
-          }));
+          jQuery.post(options.slack.webhook, JSON.stringify(getJson(options, song)));
 
           setTimeout(function() {
             checkSong(service, options);
@@ -50,6 +38,31 @@
         }, 1000);
       }
     });
+  }
+
+  function getJson(options, song) {
+      if (options.slack.attachment) {
+          return {
+            'username' : options.slack.username,
+            'icon_url' : song.cover,
+            "mrkdwn" : true,
+            "attachments": [
+              {
+                "fallback": song.title + ' - ' + song.artist + ' - ' + song.album,
+                "title": song.title,
+                "text": song.artist + ' - ' + song.album,
+                "thumb_url": song.cover
+              }
+            ]
+          }
+      } else {
+          return {
+            'username' : options.slack.username,
+            'icon_url' : song.cover,
+            "mrkdwn" : true,
+            'text' : '*' + song.title + '*\n' + song.artist + ' - ' + song.album
+          }
+      }
   }
 
   function isEmptySong(song) {

--- a/scripts/slack-music-notifier.js
+++ b/scripts/slack-music-notifier.js
@@ -29,10 +29,16 @@
           jQuery.post(options.slack.webhook, JSON.stringify({
             'username' : options.slack.username,
             'icon_url' : song.cover,
-            'text' : '*' + song.title + '*\n' + song.artist + ' - ' + song.album,
-            "mrkdwn" : true
+            "mrkdwn" : true,
+            "attachments": [
+              {
+                "fallback": song.title + ' - ' + song.artist + ' - ' + song.album,
+                "title": song.title,
+                "text": song.artist + ' - ' + song.album,
+                "thumb_url": song.cover
+              }
+            ]
           }));
-
 
           setTimeout(function() {
             checkSong(service, options);


### PR DESCRIPTION
The current simple formatting:
'_' + song.title + '_\n' + song.artist + ' - ' + song.album

Has been replaced with a message using the Attachments API
(https://api.slack.com/docs/attachments). This uses the song.title as
the attachment title, song.artist + ' - ' + song.album as the body text,
and the song.cover as the thumbnail.

A toggle to switch back to the old behaviour is included in the options.

New notification:
![image](https://cloud.githubusercontent.com/assets/2196521/8060631/69304482-0ebe-11e5-9e0c-e7ecd6252d26.png)

Switching between both:
![image](https://cloud.githubusercontent.com/assets/2196521/8060676/93023716-0ebe-11e5-8a2f-f9cad2bf3ee8.png)
![image](https://cloud.githubusercontent.com/assets/2196521/8060692/a494c778-0ebe-11e5-9288-a1e8cec914a9.png)
